### PR TITLE
Reworded hint (and fixed some minor typos)

### DIFF
--- a/content/onboard/whatisnapari.md
+++ b/content/onboard/whatisnapari.md
@@ -34,7 +34,7 @@ Napari is free-to-use, **open-source** and **community-developed**. This means t
 Napari aims to minimize (and eventually eliminate) the amount of coding knowledge needed for its use, making it friendly for researchers in life-science based fields. However as napari is still being developed and evolving as a platform, the current version (as of June 2022) requires some user understanding of the basics of: **conda**, **Python**, and **virtual environments**. These concepts will be explained in subsequent sections, where you will be guided through installing napari. Core developers are building a stable app version of napari that can be installed like other desktop apps without using code. 
 
 :::{hint}
-Although the [napari bundled app](https://napari.org/stable/tutorials/fundamentals/installation.html#install-as-a-bundled-app) already exists, it is still in-development and not entirely stable. We recommend [installing napari as a Python package](https://napari.org/stable/tutorials/fundamentals/installation.html#prerequisites-for-installing-napari-as-a-python-package) if you intend to perform cell segmentations. This note will be updated as napari evolves.
+Although the [napari bundled app](https://napari.org/stable/tutorials/fundamentals/installation.html#install-as-a-bundled-app) already exists, it is still in-development and not entirely stable. We recommend [installing napari as a Python package](https://napari.org/stable/tutorials/fundamentals/installation.html#prerequisites-for-installing-napari-as-a-python-package) if you intend to perform cell segmentation. This note will be updated as napari evolves.
 :::
 
 ## The power of Python

--- a/content/onboard/whatisnapari.md
+++ b/content/onboard/whatisnapari.md
@@ -31,10 +31,10 @@ Napari is free-to-use, **open-source** and **community-developed**. This means t
 [^mynote2]: Installable add-ons for the napari viewer which enhance its image analysis capabilities. Discoverable in the napari viewer or the [napari hub](https://www.napari-hub.org). 
 
 
-Napari aims to minimize (and eventually eliminate) the amount of coding knowledge needed for its use, making it friendly for researchers in life-science based fields. However as napari is still being developed and evolving as a platform, the current version (as of June 2022) requires some user understanding of the basics of: **conda**, **python**, and **virtual environments**. These concepts will be explained in subsequent sections, where you will be guided through installing napari. Core developers are buidling a stable app version of napari that can be installed like other desktop apps without using code. 
+Napari aims to minimize (and eventually eliminate) the amount of coding knowledge needed for its use, making it friendly for researchers in life-science based fields. However as napari is still being developed and evolving as a platform, the current version (as of June 2022) requires some user understanding of the basics of: **conda**, **Python**, and **virtual environments**. These concepts will be explained in subsequent sections, where you will be guided through installing napari. Core developers are building a stable app version of napari that can be installed like other desktop apps without using code. 
 
 :::{hint}
-Although [the napari app](https://napari.org/tutorials/fundamentals/quick_start.html#installation) already exists, we recommend against using it if you intend to perform cell segmentations with napari, because it is still in-development and not entirely stable. This note will be updated as napari evolves.
+Although the [napari bundled app](https://napari.org/stable/tutorials/fundamentals/installation.html#install-as-a-bundled-app) already exists, it is still in-development and not entirely stable. We recommend [installing napari as a Python package](https://napari.org/stable/tutorials/fundamentals/installation.html#prerequisites-for-installing-napari-as-a-python-package) if you intend to perform cell segmentations. This note will be updated as napari evolves.
 :::
 
 ## The power of Python
@@ -53,7 +53,7 @@ Napari is also interoperable with other image analysis platforms, such as [FIJI]
 
 ## Supporting materials
 
-### napari documentation
+### Napari documentation
 
 - [Napari.org 'Quick Start'](https://napari.org/tutorials/fundamentals/quick_start.html)
 


### PR DESCRIPTION
1. Reworded a hint to clearly distinguish between the napari bundled app and Python package, because it otherwise sounds like a warning against using napari itself for segmentation. Briefly discussed with @dgmccart. Also changed the 'bundled app' link to the corresponding section of the detailed installation page, instead of the quick start page – there may be pros and cons to consider here.
2. Corrected some typos and capitalization for consistency.